### PR TITLE
Fixes:

### DIFF
--- a/Assets/GameState.cs
+++ b/Assets/GameState.cs
@@ -112,20 +112,22 @@ namespace TheTileMaze
                 NumbersCollected = 0
             };
 
+            // All of the shovable tiles (every even row and column, plus the extra tile)
             var tiles = Enumerable.Repeat(TileShape.NE, 16).Concat(Enumerable.Repeat(TileShape.ESW, 6)).Concat(Enumerable.Repeat(TileShape.NS, 12)).ToArray().Shuffle();
-            var tileNumbers = Enumerable.Range(0, 10).Select(v => (int?) v).Concat(Enumerable.Repeat((int?) null, tiles.Length - 10)).ToArray().Shuffle();
             var tIx = 0;
 
-            for (var i = 0; i < _initialGrid.Length; i++)
-                if (_initialGrid[i] == null)
-                {
-                    gs.Tiles[i] = new Tile(tiles[tIx], tileNumbers[tIx]);
-                    tIx++;
-                }
-                else
-                    gs.Tiles[i] = new Tile(_initialGrid[i].Value, null);
+            // All tiles except the corners can potentially have numbers on them, the rest are “null” numbers
+            var tileNumbers = Enumerable.Range(0, 10).Select(v => (int?) v).Concat(Enumerable.Repeat((int?) null, 50 /* all tiles */ - 10 /* numbers */ - 4 /* corners */)).ToArray().Shuffle();
+            var tnIx = 0;
 
-            gs.ExtraTile = new Tile(tiles[tIx].Rotate(Rnd.Range(0, 4)), tileNumbers[tIx]);
+            for (var i = 0; i < _initialGrid.Length; i++)
+                gs.Tiles[i] = new Tile(
+                    // Place tiles from _initialGrid; fill the gaps with the shuffled tiles and rotate them randomly
+                    _initialGrid[i] != null ? _initialGrid[i].Value : tiles[tIx++].Rotate(Rnd.Range(0, 4)),
+                    // Place numbers anywhere except the corners
+                    SetStart.AllStarts.Any(s => s.TilePosition == i) ? null : tileNumbers[tnIx++]);
+
+            gs.ExtraTile = new Tile(tiles[tIx].Rotate(Rnd.Range(0, 4)), tileNumbers[tnIx]);
             return gs;
         }
 

--- a/Assets/Tile.cs
+++ b/Assets/Tile.cs
@@ -16,7 +16,7 @@ namespace TheTileMaze
 
         public Tile Rotate(int amount) { return new Tile(Shape.Rotate(amount), Number); }
 
-        public char Char { get { return "╚╔╗╝╦╣╩╠║═"[(int) Shape]; } }
+        public char Char { get { return "╚╔╗╝╦╣╩╠║═║═"[(int) Shape]; } }
 
         public bool Equals(Tile other) { return other.Shape == Shape && other.Number == Number; }
         public override int GetHashCode() { return (int) Shape * 31 + (Number ?? 10); }

--- a/Assets/TileExtensions.cs
+++ b/Assets/TileExtensions.cs
@@ -7,7 +7,7 @@ namespace TheTileMaze
         public static TileShape Clockwise(this TileShape tile)
         {
             var tileInt = (int) tile;
-            return (TileShape) (tileInt < 8 ? (tileInt & ~3) | ((tileInt % 4 + 1) % 4) : tileInt ^ 1);
+            return (TileShape) ((tileInt & ~3) | ((tileInt % 4 + 1) % 4));
         }
 
         public static TileShape Rotate(this TileShape tile, int amount)
@@ -31,7 +31,9 @@ namespace TheTileMaze
             { TileShape.NEW, new[] { true, true, false, true } },
             { TileShape.NES, new[] { true, true, true, false } },
             { TileShape.NS, new[] { true, false, true, false } },
-            { TileShape.EW, new[] { false, true, false, true } }
+            { TileShape.EW, new[] { false, true, false, true } },
+            { TileShape.SN, new[] { true, false, true, false } },
+            { TileShape.WE, new[] { false, true, false, true } }
         };
 
         public static bool IsOpenAt(this TileShape tile, Direction direction) { return _tileOpen[tile][(int) direction]; }

--- a/Assets/TileShape.cs
+++ b/Assets/TileShape.cs
@@ -16,6 +16,8 @@
 
         // Straights
         NS,
-        EW
+        EW,
+        SN,     // Looks the same as NS except when a number is on it
+        WE      // Looks the same as EW except when a number is on it
     }
 }


### PR DESCRIPTION
* Randomized tiles were not randomly rotated, oops
* Stationary tiles should be able to have numbers, too (except the corners)
* The straight pieces should be able to be rotated “upside-down” (visible when a number is on them)